### PR TITLE
Add Spotify scaffolding and mic capture

### DIFF
--- a/KaraokeApp/.gitignore
+++ b/KaraokeApp/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/KaraokeApp/Package.swift
+++ b/KaraokeApp/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "KaraokeApp",
+    platforms: [
+        .iOS(.v16), .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "KaraokeApp", targets: ["KaraokeApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "KaraokeApp",
+            path: "Sources",
+            resources: []
+        )
+    ]
+)

--- a/KaraokeApp/README.md
+++ b/KaraokeApp/README.md
@@ -1,0 +1,22 @@
+# KaraokeApp
+
+Prototype cross-platform Karaoke application for iOS and macOS.
+This demo shows the basic structure of the audio pipeline and UI
+without implementing the full Spotify or Core ML logic. It now
+includes skeleton code for authenticating with Spotify and capturing
+microphone audio.
+
+## Features
+- Connect to Spotify (Premium required)
+- Display synchronized lyrics
+- Real-time vocal attenuation using Core ML or DSP fallback
+- Capture microphone and mix with instrumental track
+- Basic Spotify App Remote integration for search and playback
+- Output audio to speakers or headphones
+
+## Building
+This package is a Swift Package for demonstration purposes only.
+Open the project in Xcode 15 or later and run on an iOS or macOS target.
+Actual Spotify authentication, audio capture from the Spotify app and
+the Core ML vocal attenuation model require additional setup that is
+beyond the scope of this repository.

--- a/KaraokeApp/Sources/AudioEngineManager.swift
+++ b/KaraokeApp/Sources/AudioEngineManager.swift
@@ -1,0 +1,59 @@
+import AVFoundation
+import Combine
+
+/// Handles audio capture, mixing and playback for the Karaoke app.
+/// Vocal attenuation is performed on the player output before it is
+/// mixed with the microphone input.
+
+final class AudioEngineManager: ObservableObject {
+    private let engine = AVAudioEngine()
+    private var micInput: AVAudioInputNode? { engine.inputNode }
+    private let player = AVAudioPlayerNode()
+    private let mixer = AVAudioMixerNode()
+    private let attenuator = VocalAttenuator()
+    private var micTapInstalled = false
+    var microphoneBufferHandler: ((AVAudioPCMBuffer, AVAudioTime) -> Void)?
+
+    /// Configures the audio engine graph with microphone and player nodes.
+    func prepareEngine() {
+        engine.attach(player)
+        engine.attach(mixer)
+
+        if let micInput {
+            engine.connect(micInput, to: mixer, format: micInput.inputFormat(forBus: 0))
+        }
+        engine.connect(player, to: mixer, format: nil)
+        engine.connect(mixer, to: engine.mainMixerNode, format: nil)
+    }
+
+    func startSession() {
+        if !micTapInstalled, let micInput {
+            micInput.installTap(onBus: 0, bufferSize: 1024, format: micInput.inputFormat(forBus: 0)) { [weak self] buffer, time in
+                self?.microphoneBufferHandler?(buffer, time)
+            }
+            micTapInstalled = true
+        }
+        do {
+            try engine.start()
+        } catch {
+            print("Engine start error: \(error)")
+        }
+    }
+
+    func stopSession() {
+        engine.stop()
+        if micTapInstalled, let micInput {
+            micInput.removeTap(onBus: 0)
+            micTapInstalled = false
+        }
+    }
+
+    /// Plays a buffer through the vocal attenuator and player node.
+    func play(buffer: AVAudioPCMBuffer) {
+        let processed = attenuator.process(buffer)
+        player.scheduleBuffer(processed, at: nil, options: [], completionHandler: nil)
+        if !player.isPlaying {
+            player.play()
+        }
+    }
+}

--- a/KaraokeApp/Sources/ContentView.swift
+++ b/KaraokeApp/Sources/ContentView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var audioEngine = AudioEngineManager()
+    @StateObject private var lyrics = LyricsManager()
+    @State private var query: String = ""
+    @State private var results: [String] = []
+    private let token = "<#Spotify Access Token#>"
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Karaoke Prototype")
+                .font(.largeTitle)
+
+            HStack {
+                TextField("Search", text: $query)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Go") {
+                    SpotifyManager.shared.search(query: query, token: token) { tracks in
+                        results = tracks
+                    }
+                }
+            }
+
+            List(results, id: \.self) { track in
+                Button(track) {
+                    // Placeholder play action
+                    lyrics.loadLyrics(for: track)
+                    SpotifyManager.shared.play(uri: track)
+                    audioEngine.startSession()
+                }
+            }
+
+            Text(lyrics.currentLine)
+                .font(.title)
+                .padding()
+
+            HStack {
+                Button("Stop") {
+                    audioEngine.stopSession()
+                }
+            }
+        }
+        .onAppear {
+            audioEngine.prepareEngine()
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/KaraokeApp/Sources/KaraokeAppApp.swift
+++ b/KaraokeApp/Sources/KaraokeAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct KaraokeAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/KaraokeApp/Sources/LyricsManager.swift
+++ b/KaraokeApp/Sources/LyricsManager.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Combine
+
+/// Manages synchronized lyrics for the currently playing track.
+final class LyricsManager: ObservableObject {
+    @Published var currentLine: String = ""
+    private var lyrics: [TimeInterval: String] = [:]
+
+    /// Loads lyrics for a track given its identifier.
+    func loadLyrics(for trackID: String) {
+        // TODO: Fetch and parse synchronized lyrics
+        lyrics = [:]
+    }
+
+    /// Updates the currently displayed lyric line based on playback time.
+    func update(at time: TimeInterval) {
+        // Simple nearest lookup placeholder
+        let line = lyrics.sorted { abs($0.key - time) < abs($1.key - time) }.first
+        currentLine = line?.value ?? ""
+    }
+}

--- a/KaraokeApp/Sources/SpotifyManager.swift
+++ b/KaraokeApp/Sources/SpotifyManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+#if canImport(SpotifyiOS)
+import SpotifyiOS
+#endif
+
+/// Lightweight wrapper around Spotify App Remote and Web APIs.
+/// Actual authentication details must be supplied by the app.
+final class SpotifyManager: NSObject {
+    static let shared = SpotifyManager()
+
+#if canImport(SpotifyiOS)
+    private var appRemote: SPTAppRemote?
+    private var sessionManager: SPTSessionManager?
+#endif
+
+    func connect(clientID: String, redirectURL: URL) {
+#if canImport(SpotifyiOS)
+        let configuration = SPTConfiguration(clientID: clientID, redirectURL: redirectURL)
+        let manager = SPTSessionManager(configuration: configuration, delegate: nil)
+        sessionManager = manager
+        manager.initiateSession(with: [.appRemoteControl], options: .default)
+        appRemote = SPTAppRemote(configuration: configuration, logLevel: .debug)
+#endif
+    }
+
+    func search(query: String, token: String, completion: @escaping ([String]) -> Void) {
+        guard let url = URL(string: "https://api.spotify.com/v1/search?q=\(query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&type=track&limit=10") else {
+            completion([])
+            return
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let tracks = ((json["tracks"] as? [String: Any])?["items"] as? [[String: Any]]) else {
+                completion([])
+                return
+            }
+            let uris = tracks.compactMap { $0["uri"] as? String }
+            completion(uris)
+        }.resume()
+    }
+
+    func play(uri: String) {
+#if canImport(SpotifyiOS)
+        appRemote?.playerAPI?.play(uri, callback: nil)
+#endif
+    }
+
+    func pause() {
+#if canImport(SpotifyiOS)
+        appRemote?.playerAPI?.pause(nil)
+#endif
+    }
+}

--- a/KaraokeApp/Sources/VocalAttenuator.swift
+++ b/KaraokeApp/Sources/VocalAttenuator.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import CoreML
+
+/// Placeholder vocal attenuation using Core ML.
+/// In a real application, this would load the converted Spleeter model
+/// and process buffers to attenuate vocals.
+final class VocalAttenuator {
+    private var model: MLModel?
+
+    init(modelURL: URL? = nil) {
+        if let url = modelURL {
+            model = try? MLModel(contentsOf: url)
+        }
+    }
+
+    /// Processes an audio buffer and returns an instrumental buffer
+    /// with vocals attenuated. Currently a no-op placeholder.
+    func process(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer {
+        // TODO: Run Core ML model or DSP here
+        return buffer
+    }
+}


### PR DESCRIPTION
## Summary
- expand README with Spotify notes
- attach microphone tap for processing
- add Spotify API scaffold using SpotifyAppRemote
- request track search using access token
- play selected result and start engine

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_686a7b7f9d748333a8f52263d9e5aff4